### PR TITLE
Endoint Async Await Fixes

### DIFF
--- a/Tentacles.xcodeproj/project.pbxproj
+++ b/Tentacles.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		C17981C3297F2AB300D52475 /* Endpoint+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17981C1297F2AB300D52475 /* Endpoint+Result.swift */; };
 		C17981C4297F2AB700D52475 /* Endpoint+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17981C1297F2AB300D52475 /* Endpoint+Result.swift */; };
 		C17981C5297F2ABA00D52475 /* Endpoint+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17981C0297F2AB300D52475 /* Endpoint+AsyncAwait.swift */; };
+		C1EF4AC42988C194001337A8 /* EndpointAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EF4AC22988C194001337A8 /* EndpointAsyncTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +136,7 @@
 		1CFC160A217515230017A3DB /* MockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTests.swift; sourceTree = "<group>"; };
 		C17981C0297F2AB300D52475 /* Endpoint+AsyncAwait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Endpoint+AsyncAwait.swift"; path = "Tentacles/Endpoint+AsyncAwait.swift"; sourceTree = "<group>"; };
 		C17981C1297F2AB300D52475 /* Endpoint+Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Endpoint+Result.swift"; path = "Tentacles/Endpoint+Result.swift"; sourceTree = "<group>"; };
+		C1EF4AC22988C194001337A8 /* EndpointAsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointAsyncTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -236,6 +238,7 @@
 				1C5DBB492073F79C00ABC4B1 /* TentaclesTests.swift */,
 				1C0ED7E8221E71C500C788BD /* URLTests.swift */,
 				1CB6CEA6287B7CF500A6BF41 /* ThrottleTests.swift */,
+				C1EF4AC22988C194001337A8 /* EndpointAsyncTests.swift */,
 			);
 			path = TentaclesTests;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				1C13BA23249D4E00002BE077 /* JsonEndpoint.swift in Sources */,
 				C17981C5297F2ABA00D52475 /* Endpoint+AsyncAwait.swift in Sources */,
 				1CFC160B217515230017A3DB /* MockTests.swift in Sources */,
+				C1EF4AC42988C194001337A8 /* EndpointAsyncTests.swift in Sources */,
 				1CB6CEAB287B971700A6BF41 /* Throttle.swift in Sources */,
 				1C0ED7E9221E71C500C788BD /* URLTests.swift in Sources */,
 				1CCF1378206F089F00231DC0 /* GetTests.swift in Sources */,

--- a/Tentacles/Endpoint+AsyncAwait.swift
+++ b/Tentacles/Endpoint+AsyncAwait.swift
@@ -27,7 +27,7 @@ extension Endpoint {
                 return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Output, Error>) -> Void in
                     self.get(
                         path: path,
-                        parameters: nil,
+                        parameters: parameters,
                         dateFormatters: dateFormatters) { result in
                             continuation.resume(with: result)
                         }

--- a/TentaclesTests/EndpointAsyncTests.swift
+++ b/TentaclesTests/EndpointAsyncTests.swift
@@ -1,0 +1,75 @@
+//
+//  EndpointAsyncTests.swift
+//  Tentacles
+//
+//  Created by Donald Largen on 1/30/23.
+//  Copyright © 2023 Squid Store. All rights reserved.
+//
+
+import XCTest
+
+final class EndpointAsyncTests: XCTestCase {
+
+    struct GetResult: Codable {
+        let args: [String: String]
+    }
+    
+    func testGet () async throws {
+          
+        let sessionConfig = Session.SessionConfiguration(
+            scheme: "http",
+            host: "httpbin.org",
+            authorizationHeaderKey: nil,
+            authorizationHeaderValue: nil,
+            headers: nil,
+            isWrittingDisabled: false,
+            timeout: 60)
+            let session = Session()
+            session.sessionConfiguration = sessionConfig
+        
+        let endPoint = Endpoint(session: session)
+        let params = ["foo": "bar"]
+        
+        let getResult:GetResult = try await endPoint.get(
+            path: "get",
+            parameters: params,
+            dateFormatters: [])
+        
+        guard getResult.args["foo"] == "bar" else {
+              XCTFail()
+              return
+        }
+    }
+    
+    func testPost() async throws {
+        let body = ["title": 100]
+        
+        let sessionConfig = Session.SessionConfiguration(
+            scheme: "https",
+            host: "jsonplaceholder.typicode.com",
+            authorizationHeaderKey: nil,
+            authorizationHeaderValue: nil,
+            headers: nil,
+            isWrittingDisabled: false,
+            timeout: 60)
+            
+            let session = Session()
+            session.sessionConfiguration = sessionConfig
+    
+            let endPoint = Endpoint(session: session)
+            let inputFormatter = DateFormatter()
+            
+            let postResult: [String: Int] = try await endPoint.post(
+                path: "posts",
+                body: body,
+                inputDateFormatter: inputFormatter,
+                dateFormatters: [])
+            
+            guard postResult["title"] == 100 else {
+                XCTFail("Title should be 100")
+                return
+            }
+            
+        }
+}
+


### PR DESCRIPTION
When issuing a Get using the Endpoint async/await wrapper the parameters were not being passed correctly.

Added unit test