### PR TITLE
End point async wait and result fixes

### DIFF
--- a/Tentacles/Endpoint+AsyncAwait.swift
+++ b/Tentacles/Endpoint+AsyncAwait.swift
@@ -44,18 +44,19 @@ extension Endpoint {
         body: Input,
         inputDateFormatter: DateFormatter,
         dateFormatters: [DateFormatter],
+        keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
         keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys) async throws -> Output {
             
             return try await withTaskCancellationHandler(operation: {
                 return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Output, Error>) -> Void in
-                    self.post(
-                        path: path,
-                        body: body,
-                        inputDateFormatter: inputDateFormatter,
-                        dateFormatters: dateFormatters,
-                        keyDecodingStrategy: keyDecodingStrategy) { result in
-                            continuation.resume(with: result)
-                        }
+                    self.post(path: path,
+                              body: body,
+                              inputDateFormatter: inputDateFormatter,
+                              dateFormatters: dateFormatters,
+                              keyEncodingStrategy: keyEncodingStrategy,
+                              keyDecodingStrategy: keyDecodingStrategy) { result in
+                        continuation.resume(with: result)
+                    }
                 })
             }, onCancel: {
                 Tentacles.shared.logger?.log("Endpoint Post request canceled", level: .info)
@@ -63,19 +64,20 @@ extension Endpoint {
             })
     }
     
-    public func post<Input: Encodable >(
+    public func post<Input: Encodable>(
         path: String,
         body: Input,
-        inputDateFormatter: DateFormatter ) async throws -> Void {
+        inputDateFormatter: DateFormatter,
+        keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys) async throws -> Void {
             
             return try await withTaskCancellationHandler(operation: {
                 return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Void, Error>) -> Void in
-                    self.post(
-                        path: path,
-                        body: body,
-                        inputDateFormatter: inputDateFormatter) { result in
-                            continuation.resume(with: result)
-                        }
+                    self.post(path: path,
+                              body: body,
+                              inputDateFormatter: inputDateFormatter,
+                              keyEncodingStrategy: keyEncodingStrategy) { result in
+                        continuation.resume(with: result)
+                    }
                 })
             }, onCancel: {
                 Tentacles.shared.logger?.log("Endpoint Post request canceled", level: .info)
@@ -88,18 +90,19 @@ extension Endpoint {
         body: Input,
         inputDateFormatter: DateFormatter,
         dateFormatters: [DateFormatter],
+        keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
         keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys) async throws -> Output {
             
             return try await withTaskCancellationHandler(operation: {
                 return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Output, Error>) -> Void in
-                    self.put(
-                        path: path,
-                        body: body,
-                        inputDateFormatter: inputDateFormatter,
-                        dateFormatters: dateFormatters,
-                        keyDecodingStrategy: keyDecodingStrategy) { result in
-                            continuation.resume(with: result)
-                        }
+                    self.put(path: path,
+                             body: body,
+                             inputDateFormatter: inputDateFormatter,
+                             dateFormatters: dateFormatters,
+                             keyEncodingStrategy: keyEncodingStrategy,
+                             keyDecodingStrategy: keyDecodingStrategy) { result in
+                        continuation.resume(with: result)
+                    }
                 })
             }, onCancel: {
                 Tentacles.shared.logger?.log("Endpoint Put request canceled", level: .info)
@@ -110,16 +113,17 @@ extension Endpoint {
     public func put<Input: Encodable> (
         path: String,
         body: Input,
-        inputDateFormatter: DateFormatter ) async throws -> Void {
+        inputDateFormatter: DateFormatter,
+        keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys) async throws -> Void {
             
             return try await withTaskCancellationHandler(operation: {
                 return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<Void, Error>) -> Void in
-                    self.put(
-                        path: path,
-                        body: body,
-                        inputDateFormatter: inputDateFormatter ) { result in
-                            continuation.resume(with: result)
-                        }
+                    self.put(path: path,
+                             body: body,
+                             inputDateFormatter: inputDateFormatter,
+                             keyEncodingStrategy: keyEncodingStrategy) { result in
+                        continuation.resume(with: result)
+                    }
                 })
             }, onCancel: {
                 Tentacles.shared.logger?.log("Endpoint Put request canceled", level: .info)

--- a/Tentacles/Endpoint+Result.swift
+++ b/Tentacles/Endpoint+Result.swift
@@ -54,92 +54,94 @@ extension Endpoint {
     }
     
     //post with no response.
-   public func post<Input: Encodable> (
-        path: String,
-        body: Input,
-        inputDateFormatter: DateFormatter,
-        completion: @escaping (Swift.Result<Void, APIError>) -> ()) {
+   public func post<Input: Encodable>(path: String,
+                                       body: Input,
+                                       inputDateFormatter: DateFormatter,
+                                       keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
+                                       completion: @escaping (Swift.Result<Void, APIError>) -> ()) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
+            encoder.keyEncodingStrategy = keyEncodingStrategy
+            let data = try encoder.encode(body)
             
-            do {
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
-                let data = try encoder.encode(body)
-                
-                self.post(
-                    path,
-                    parameterType: .custom("application/json"),
-                    parameters: data,
-                    responseType: .json,
-                    completion: self.handleVoidResponse(completion: completion))
-            }
-            catch {
-                completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
-            }
+            self.post(path,
+                      parameterType: .custom("application/json"),
+                      parameters: data,
+                      responseType: .none,
+                      completion: self.handleVoidResponse(completion: completion))
+        }
+        catch {
+            completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
+        }
     }
     
-    public func post<Input: Encodable, Output: Decodable >(
-        path: String,
-        body: Input,
-        inputDateFormatter: DateFormatter,
-        dateFormatters: [DateFormatter],
-        keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys,
-        completion: @escaping (Swift.Result<Output, APIError>) -> ()) {
+    public func post<Input: Encodable, Output: Decodable >(path: String,
+                                                           body: Input,
+                                                           inputDateFormatter: DateFormatter,
+                                                           dateFormatters: [DateFormatter],
+                                                           keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
+                                                           keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys,
+                                                           completion: @escaping (Swift.Result<Output, APIError>) -> ()) {
+        
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
+            encoder.keyEncodingStrategy = keyEncodingStrategy
+            let data = try encoder.encode(body)
             
-            do {
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
-                let data = try encoder.encode(body)
-                
-                self.post(
-                    path,
-                    parameterType: .custom("application/json"),
-                    parameters: data,
-                    responseType: .json,
-                    completion: self.handleResponse(dateFormatters: dateFormatters,
-                                                    keyDecodingStrategy: keyDecodingStrategy,
-                                                    completion: completion))
-            }
-            catch {
-                completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
-            }
+            self.post(
+                path,
+                parameterType: .custom("application/json"),
+                parameters: data,
+                responseType: .json,
+                completion: self.handleResponse(dateFormatters: dateFormatters,
+                                                keyDecodingStrategy: keyDecodingStrategy,
+                                                completion: completion))
+        }
+        catch {
+            completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
+        }
     }
 
-    public func put<Input: Encodable, Output: Decodable>(
-        path: String,
-        body: Input,
-        inputDateFormatter: DateFormatter,
-        dateFormatters: [DateFormatter],
-        keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys,
-        completion: @escaping (Swift.Result<Output, APIError>) -> ()) {
+    public func put<Input: Encodable, Output: Decodable>(path: String,
+                                                         body: Input,
+                                                         inputDateFormatter: DateFormatter,
+                                                         dateFormatters: [DateFormatter],
+                                                         keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
+                                                         keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys,
+                                                         completion: @escaping (Swift.Result<Output, APIError>) -> ()) {
         
-            do {
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
-                let data = try encoder.encode(body)
-                
-                self.put(
-                    path,
-                    parameterType: .custom("application/json"),
-                    parameters: data,
-                    completion: self.handleResponse(
-                        dateFormatters: dateFormatters,
-                        keyDecodingStrategy: keyDecodingStrategy,
-                        completion: completion))
-            }
-            catch {
-                completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
-            }
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
+            encoder.keyEncodingStrategy = keyEncodingStrategy
+            let data = try encoder.encode(body)
+            
+            self.put(
+                path,
+                parameterType: .custom("application/json"),
+                parameters: data,
+                completion: self.handleResponse(dateFormatters: dateFormatters,
+                                                keyDecodingStrategy: keyDecodingStrategy,
+                                                completion: completion))
+        }
+        catch {
+            completion(.failure(session.apiError(errorType: .encode, error: error, response: nil)))
+        }
     }
 
     public func put<Input: Encodable> (
         path: String,
         body: Input,
         inputDateFormatter: DateFormatter,
+        keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys,
         completion: @escaping (Swift.Result<Void, APIError>) -> ()) {
             
             do {
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .formatted(inputDateFormatter)
+                encoder.keyEncodingStrategy = keyEncodingStrategy
                 let data = try encoder.encode(body)
                 
                 self.put(


### PR DESCRIPTION
Added encoding key parameter to put and post calls with default value.  
Put call that does not return a value was not specifying the correct return type.  Changed from .json and to .none